### PR TITLE
Updated lib/mongoq.js to support new release of mongodb dependency.

### DIFF
--- a/lib/mongoq.js
+++ b/lib/mongoq.js
@@ -151,7 +151,7 @@ function mongoq( dbnameOrUrl, options ) {
 		for( var key in options ) {
 			op[ key ] = options[ key ];
 		}
-		server = new mongodb.ReplSetServers(servers, op);
+		server = new mongodb.ReplSet(servers, op);
 	}
 
 	/** auth */

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
 	  "url" : "http://github.com/zzdhidden/mongoq.git" 
 	}
   , "dependencies": { 
-	  "mongodb" : ">=0.9.1"
-	, "jquery-deferred": ">=0.2.0" 
+	  "mongodb" : "^2.0.23"
+	, "jquery-deferred": "^0.2.0" 
 	}
   , "devDependencies": { 
 	  "mocha" : "*"


### PR DESCRIPTION
Unless this PR is merged, mongoq module is absolutely usless when connecting to replicasets..