### PR TITLE
Revert mongodb back to 1.x.x

### DIFF
--- a/lib/mongoq.js
+++ b/lib/mongoq.js
@@ -151,7 +151,7 @@ function mongoq( dbnameOrUrl, options ) {
 		for( var key in options ) {
 			op[ key ] = options[ key ];
 		}
-		server = new mongodb.ReplSet(servers, op);
+		server = new mongodb.ReplSetServers(servers, op);
 	}
 
 	/** auth */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongoq"
-  , "version": "0.2.4"
+  , "version": "0.2.5"
   , "description": "Use mongoDB like this: require('mongoq')('testdb').collection('users').find(function(err, cursor){});"
   , "keywords": ["mongodb", "mongoq", "data", "datastore", "nosql"]
   , "author" : "Hidden <zzdhidden@gmail.com>"
@@ -9,7 +9,7 @@
 	  "url" : "http://github.com/zzdhidden/mongoq.git" 
 	}
   , "dependencies": { 
-	  "mongodb" : "^2.0.23"
+	  "mongodb" : "^1.4.35"
 	, "jquery-deferred": "^0.2.0" 
 	}
   , "devDependencies": { 


### PR DESCRIPTION
Use mongodb 1.x.x.
Using mongodb 2.x.x requires mongoq refactoring.